### PR TITLE
feat: created typo elements, added basic markup for Verify Email Page…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
+        "@mui/base": "^5.0.0-beta.40",
         "@mui/lab": "^5.0.0-alpha.170",
         "@mui/material": "^5.15.18",
         "@mui/system": "^5.15.15",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
+    "@mui/base": "^5.0.0-beta.40",
     "@mui/lab": "^5.0.0-alpha.170",
     "@mui/material": "^5.15.18",
     "@mui/system": "^5.15.15",

--- a/src/components/ExampleForm/index.tsx
+++ b/src/components/ExampleForm/index.tsx
@@ -16,7 +16,7 @@ export default function ExampleForm() {
   });
 
   const onSubmit: SubmitHandler<IFormInput> = (data) => {
-    console.log(data);
+    return data;
   };
 
   return (

--- a/src/components/shared/ButtonText/index.tsx
+++ b/src/components/shared/ButtonText/index.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from 'react';
+import { Typography } from '@mui/material';
+import theme from 'src/theme';
+
+interface IButtonTextProps {
+  children: ReactNode;
+}
+
+function ButtonText({ children }: IButtonTextProps) {
+  return (
+    <Typography
+      variant="button"
+      align="center"
+      sx={{ color: theme.palette.common.white }}
+    >
+      {children}
+    </Typography>
+  );
+}
+
+export default ButtonText;

--- a/src/components/shared/LabelText/index.tsx
+++ b/src/components/shared/LabelText/index.tsx
@@ -1,0 +1,28 @@
+import { ReactNode } from 'react';
+import { Typography } from '@mui/material';
+import theme from 'src/theme';
+
+interface ILabelTextProps {
+  children: ReactNode;
+  align?: 'right' | 'left' | 'center' | 'inherit' | 'justify' | undefined;
+}
+
+const defaultProps = {
+  align: 'left',
+};
+
+function LabelText({ children, align }: ILabelTextProps) {
+  return (
+    <Typography
+      variant="subtitle1"
+      align={align}
+      sx={{ color: theme.palette.primary.main }}
+    >
+      {children}
+    </Typography>
+  );
+}
+
+LabelText.defaultProps = defaultProps;
+
+export default LabelText;

--- a/src/components/shared/RegularText/index.tsx
+++ b/src/components/shared/RegularText/index.tsx
@@ -1,0 +1,28 @@
+import { ReactNode } from 'react';
+import { Typography } from '@mui/material';
+import theme from 'src/theme';
+
+interface IRegularTextProps {
+  children: ReactNode;
+  align?: 'right' | 'left' | 'center' | 'inherit' | 'justify' | undefined;
+}
+
+const defaultProps = {
+  align: 'left',
+};
+
+function RegularText({ children, align }: IRegularTextProps) {
+  return (
+    <Typography
+      variant="subtitle2"
+      align={align}
+      sx={{ color: theme.palette.text.disabled }}
+    >
+      {children}
+    </Typography>
+  );
+}
+
+RegularText.defaultProps = defaultProps;
+
+export default RegularText;

--- a/src/components/shared/StyledButton/index.tsx
+++ b/src/components/shared/StyledButton/index.tsx
@@ -1,9 +1,9 @@
 import { styled } from '@mui/system';
 import { LoadingButton } from '@mui/lab';
-import { StyledButtonProps } from './types';
+import { IStyledButtonProps } from './types';
 import { ButtonPaddings, ButtonStyles } from './styles';
 
-const StyledButton = styled(LoadingButton)<StyledButtonProps>(
+const StyledButton = styled(LoadingButton)<IStyledButtonProps>(
   ({ theme, ...props }) => ({
     width: props.width,
     boxShadow: 'none',

--- a/src/components/shared/StyledButton/types.ts
+++ b/src/components/shared/StyledButton/types.ts
@@ -15,7 +15,7 @@ export enum PaddingVariants {
   XL = 'xl',
 }
 
-export interface StyledButtonProps extends ButtonProps {
+export interface IStyledButtonProps extends ButtonProps {
   width?: string;
   radius?: string;
   styles: StyleVariants;

--- a/src/components/shared/TextButton/index.tsx
+++ b/src/components/shared/TextButton/index.tsx
@@ -4,12 +4,14 @@ import { Button } from '@mui/material';
 const TextButton = styled(Button)(({ theme }) => ({
   boxShadow: 'none',
   textTransform: 'none',
-  fontSize: 14,
   padding: '16px 24px',
-  width: '10%',
-  lineHeight: 1,
-  color: theme.palette.text.primary,
   cursor: 'pointer',
+  '&:hover, &:active, &:focus': {
+    backgroundColor: 'transparent',
+  },
+  '&:hover, &:disabled': {
+    opacity: theme.palette.action.hoverOpacity,
+  },
 }));
 
 export default TextButton;

--- a/src/components/shared/Title/index.tsx
+++ b/src/components/shared/Title/index.tsx
@@ -1,0 +1,28 @@
+import { ReactNode } from 'react';
+import { Typography } from '@mui/material';
+import theme from 'src/theme';
+
+interface ITitleProps {
+  children: ReactNode;
+  align?: 'right' | 'left' | 'center' | 'inherit' | 'justify' | undefined;
+}
+
+const defaultProps = {
+  align: 'left',
+};
+
+function Title({ children, align }: ITitleProps) {
+  return (
+    <Typography
+      variant="h1"
+      sx={{ color: theme.palette.primary.main }}
+      align={align}
+    >
+      {children}
+    </Typography>
+  );
+}
+
+Title.defaultProps = defaultProps;
+
+export default Title;

--- a/src/locales/en/exampleTranslation.json
+++ b/src/locales/en/exampleTranslation.json
@@ -5,5 +5,13 @@
   "examplePageText": {
     "homePage": "Home Page",
     "signInPage": "Sing In"
+  },
+  "verifyEmail": {
+    "verifyYourEmail": "Verify your email",
+    "sentEmailText": "We have sent an OTP verification code to your email, please enter it here",
+    "code": "Code",
+    "verify": "Verify",
+    "expire": "will expire in 00:",
+    "sendAgain": "Send Again"
   }
 }

--- a/src/pages/VerifyEmailPage/index.tsx
+++ b/src/pages/VerifyEmailPage/index.tsx
@@ -1,0 +1,80 @@
+import { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Box, IconButton } from '@mui/material';
+import ArrowLeftIcon from 'src/assets/icons/arrow-left.svg';
+import StyledButton from 'src/components/shared/StyledButton';
+import {
+  PaddingVariants,
+  StyleVariants,
+} from 'src/components/shared/StyledButton/types';
+import Title from 'src/components/shared/Title';
+import RegularText from 'src/components/shared/RegularText';
+import LabelText from 'src/components/shared/LabelText';
+import TextButton from 'src/components/shared/TextButton';
+import ButtonText from 'src/components/shared/ButtonText';
+
+function VerifyEmailPage() {
+  const timerMin: number = 0;
+  const timerMax: number = 55;
+  const intervalStep: number = 1000;
+  const symbolsForTimer: number = 2;
+
+  const { t } = useTranslation();
+  const [timer, setTimer] = useState<number>(timerMax);
+
+  const formattedTimer = timer.toString().padStart(symbolsForTimer, '0');
+  const isSendAgainButtonDisabled = timer > timerMin;
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      if (timer > timerMin) {
+        setTimer(timer - 1);
+      }
+    }, intervalStep);
+
+    return () => clearInterval(interval);
+  }, [timer]);
+
+  const handleSendAgain = () => {
+    setTimer(timerMax);
+  };
+
+  return (
+    <Box
+      display="flex"
+      flexDirection="column"
+      width="350px"
+      justifyContent="flex-start"
+    >
+      <Box display="flex">
+        <IconButton>
+          <ArrowLeftIcon />
+        </IconButton>
+        <Title>{t('verifyEmail.verifyYourEmail')}</Title>
+      </Box>
+      <RegularText align="left">{t('verifyEmail.sentEmailText')}</RegularText>
+      <LabelText align="left">{t('verifyEmail.code')}</LabelText>
+      <Box display="flex" justifyContent="space-between" alignItems="center">
+        <RegularText align="left">
+          {t('verifyEmail.expire')}
+          {formattedTimer}
+        </RegularText>
+        <TextButton
+          onClick={handleSendAgain}
+          disabled={isSendAgainButtonDisabled}
+        >
+          <LabelText align="right">{t('verifyEmail.sendAgain')}</LabelText>
+        </TextButton>
+      </Box>
+      <StyledButton
+        styles={StyleVariants.BLACK}
+        padding={PaddingVariants.LG}
+        variant="contained"
+      >
+        <ButtonText>{t('verifyEmail.verify')}</ButtonText>
+      </StyledButton>
+    </Box>
+  );
+}
+
+export default VerifyEmailPage;

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -2,10 +2,12 @@ import { createBrowserRouter } from 'react-router-dom';
 import HomePage from 'src/pages/HomePage';
 import SignInPage from 'src/pages/SignInPage';
 import SignUpPage from 'src/pages/SignUpPage';
+import VerifyEmailPage from 'src/pages/VerifyEmailPage';
 
 const router = createBrowserRouter([
   { path: '', element: <HomePage /> },
   { path: 'signup', element: <SignUpPage /> },
+  { path: 'verify', element: <VerifyEmailPage /> },
   { path: 'signin', element: <SignInPage /> },
 ]);
 

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -22,18 +22,18 @@ const theme = createTheme({
   palette: {
     common: {
       black: '#000000',
-      white: 'ffffff',
+      white: '#ffffff',
     },
     primary: {
       main: '#333333',
       light: '#EDEAE9',
-      contrastText: 'ffffff',
+      contrastText: '#ffffff',
     },
     secondary: {
       main: '#E3EEE2',
     },
     background: {
-      default: 'ffffff',
+      default: '#ffffff',
       paper: '#EDEAE9',
     },
     text: {
@@ -74,7 +74,7 @@ const theme = createTheme({
     subtitle1: {
       fontFamily: 'Playfair Display, Arial, sans-serif',
       fontSize: 14,
-      fontWeightRegular: 600,
+      fontWeight: 600,
       lineHeight: 1.43,
       letterSpacing: '-0.21px',
     },
@@ -92,11 +92,12 @@ const theme = createTheme({
       letterSpacing: '-0.24px',
     },
     button: {
-      fontFamily: 'DM Sans, Arial, sans-serif',
+      fontFamily: 'Playfair Display, Arial, sans-serif',
       fontSize: 16,
       fontWeight: 500,
       letterSpacing: '-0.5px',
       textTransform: 'none',
+      lineHeight: 1.32,
     },
   },
 });


### PR DESCRIPTION
…, timer, disable the Send Again button when the timer is on

## Describe your changes

- Added typo reusable elements which will be used very frequently;
- Added basic markup for Verify Email page;
- Added 55 seconds timer which starts counting down when the user arrives to the page;
- Disabled the Send Again button when the timer counts down;
- Fixed linting issues;

## Issue ticket code (and/or) and link

- [Link to JIRA ticket](https://2024internship.atlassian.net/jira/software/projects/SCRUM/boards/1/backlog?selectedIssue=SCRUM-7)

### **General**

- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [ ] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [ ] Date and time formats are on the constants
- [ ] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend

- [ ] Components and business logic are separated
- [x] Colors, Font Size, and Font Name is on the theme or in the constants
- [x] No text in the components, use i18n approach
- [x] No inline styles
- [x] Imports are absolute
- [x] Attach a screenshot if PR has visual changes.
![verify-screen](https://github.com/ZenBit-Tech/code-lions_fe/assets/156825237/e9f0ec65-b91a-4516-a11a-b548e056e045)
